### PR TITLE
[fix]修复检查报价物品功能异常的bug

### DIFF
--- a/plugins/BuffAutoAcceptOffer.py
+++ b/plugins/BuffAutoAcceptOffer.py
@@ -348,8 +348,9 @@ class BuffAutoAcceptOffer:
                                                 ]:
                                                     if item[property_to_compare] != item_in_trade[property_to_compare]:
                                                         break
-                                                match = True
-                                                break
+                                                else:
+                                                    match = True
+                                                    break
                                             if not match:
                                                 self.logger.error("[BuffAutoAcceptOffer] 报价中的物品不在待发货列表中, 跳过接受报价")
                                                 if "item_mismatch_notification" in self.config["buff_auto_accept_offer"]:


### PR DESCRIPTION
看代码的时候发现"检查报价物品"功能一直是有问题的，下面这段语句中的break只会退出当前的for循环，所以无论属性匹配与否都会将`match = True`语句。

```python
for property_to_compare in [
    "appid",
    "assetid",
    "classid",
    "contextid",
    "instanceid",
]:
    if item[property_to_compare] != item_in_trade[property_to_compare]:
        break
match = True
```
