### PR TITLE
修复编译版 ftqq通知 bug，增加pushplus通知支持，增加Buff二维码登陆图片在内容里通知开关

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ test.py
 build/*
 dist/*
 steamauto.spec
+*.spec

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ pyvenv.cfg
 qrcode.png
 env
 test.py
+build/*
+dist/*
+steamauto.spec

--- a/Apprise/__init__.py
+++ b/Apprise/__init__.py
@@ -1,0 +1,2 @@
+from .pushplus import *
+from .server_chan import *

--- a/Apprise/pushplus.py
+++ b/Apprise/pushplus.py
@@ -1,0 +1,36 @@
+import requests
+from apprise import logger
+from apprise.decorators import notify
+
+@notify(on="pushplus", name="pushplus通知插件")
+def pushplus_notification_wrapper(body, title, notify_type, *args, **kwargs):
+    token = kwargs['meta']['host']
+    url = 'http://www.pushplus.plus/send'
+    headers = {'Content-Type': 'application/json'}
+    payload = {
+        'token': token,
+        'title': title,
+        'content': body,
+        'template': 'html'
+    }
+    
+    try:
+        resp = requests.post(url, json=payload, headers=headers, timeout=10)
+        resp.raise_for_status()
+        json_response = resp.json()
+        if json_response.get('code') == 200:
+            logger.info('pushplus通知发送成功\n')
+            return True
+        else:
+            logger.error(f"pushplus通知发送失败, return code = {json_response.get('code')}")
+            return False
+    except requests.exceptions.HTTPError as http_err:
+        logger.error(f'HTTP error occurred: {http_err}')
+    except requests.exceptions.Timeout as timeout_err:
+        logger.error(f'Timeout error: {timeout_err}')
+    except requests.exceptions.RequestException as req_err:
+        logger.error(f'Request exception: {req_err}')
+    except Exception as e:
+        logger.error('pushplus通知插件发送失败！')
+        logger.error(str(e))
+    return False

--- a/Apprise/server_chan.py
+++ b/Apprise/server_chan.py
@@ -2,29 +2,35 @@ import requests
 from apprise import logger
 from apprise.decorators import notify
 
-
 @notify(on="ftqq", name="Server酱通知插件")
 def server_chan_notification_wrapper(body, title, notify_type, *args, **kwargs):
     token = kwargs['meta']['host']
+    params = {
+        'title': title,
+        'desp': body
+    }
+    url = f'https://sctapi.ftqq.com/{urllib.parse.quote(token)}.send'
     try:
-        resp = requests.get('https://sctapi.ftqq.com/%s.send?title=%s&desp=%s' % (token, title, body))
-        if resp.status_code == 200:
-            if resp.json()['code'] == 0:
-                logger.info('Server酱通知发送成功\n')
-                return True
-            else:
-                logger.error('Server酱通知发送失败, return code = %d' % resp.json()['code'])
-                return False
+        resp = requests.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        json_response = resp.json()
+        if json_response['code'] == 0:
+            logger.info('Server酱通知发送成功\n')
+            return True
         else:
-            logger.error('Server酱通知发送失败, http return code = %s' % resp.status_code)
+            logger.error(f"Server酱通知发送失败, return code = {json_response['code']}")
             return False
+    except requests.exceptions.HTTPError as http_err:
+        logger.error(f'HTTP error occurred: {http_err}')
+    except requests.exceptions.Timeout as timeout_err:
+        logger.error(f'Timeout error: {timeout_err}')
     except Exception as e:
         logger.error('Server酱通知插件发送失败！')
-        logger.error(e)
-        return False
+        logger.error(str(e))
+    return False
 
 @notify(on="pushplus", name="pushplus通知插件")
-def server_chan_notification_wrapper(body, title, notify_type, *args, **kwargs):
+def pushplus_notification_wrapper(body, title, notify_type, *args, **kwargs):
     token = kwargs['meta']['host']
     url = 'http://www.pushplus.plus/send'
     headers = {'Content-Type': 'application/json'}
@@ -36,21 +42,22 @@ def server_chan_notification_wrapper(body, title, notify_type, *args, **kwargs):
     }
     
     try:
-        resp = requests.post(url, json=payload, headers=headers)
-        if resp.status_code == 200:
-            if resp.json()['code'] == 200:
-                logger.info('pushplus通知发送成功\n')
-                return True
-            else:
-                logger.error('pushplus通知发送失败, return code = %d' % resp.json()['code'])
-                return False
+        resp = requests.post(url, json=payload, headers=headers, timeout=10)
+        resp.raise_for_status()
+        json_response = resp.json()
+        if json_response.get('code') == 200:
+            logger.info('pushplus通知发送成功\n')
+            return True
         else:
-            logger.error('pushplus通知发送失败, http return code = %s' % resp.status_code)
+            logger.error(f"pushplus通知发送失败, return code = {json_response.get('code')}")
             return False
+    except requests.exceptions.HTTPError as http_err:
+        logger.error(f'HTTP error occurred: {http_err}')
+    except requests.exceptions.Timeout as timeout_err:
+        logger.error(f'Timeout error: {timeout_err}')
+    except requests.exceptions.RequestException as req_err:
+        logger.error(f'Request exception: {req_err}')
     except Exception as e:
         logger.error('pushplus通知插件发送失败！')
-        logger.error(e)
-        return False
-
-    # Returning True/False is a way to relay your status back to Apprise.
-    # Returning nothing (None by default) is always interpreted as a Success
+        logger.error(str(e))
+    return False

--- a/Apprise/server_chan.py
+++ b/Apprise/server_chan.py
@@ -2,62 +2,26 @@ import requests
 from apprise import logger
 from apprise.decorators import notify
 
+
 @notify(on="ftqq", name="Server酱通知插件")
 def server_chan_notification_wrapper(body, title, notify_type, *args, **kwargs):
     token = kwargs['meta']['host']
-    params = {
-        'title': title,
-        'desp': body
-    }
-    url = f'https://sctapi.ftqq.com/{urllib.parse.quote(token)}.send'
     try:
-        resp = requests.get(url, params=params, timeout=10)
-        resp.raise_for_status()
-        json_response = resp.json()
-        if json_response['code'] == 0:
-            logger.info('Server酱通知发送成功\n')
-            return True
+        resp = requests.get('https://sctapi.ftqq.com/%s.send?title=%s&desp=%s' % (token, title, body))
+        if resp.status_code == 200:
+            if resp.json()['code'] == 0:
+                logger.info('Server酱通知发送成功\n')
+                return True
+            else:
+                logger.error('Server酱通知发送失败, return code = %d' % resp.json()['code'])
+                return False
         else:
-            logger.error(f"Server酱通知发送失败, return code = {json_response['code']}")
+            logger.error('Server酱通知发送失败, http return code = %s' % resp.status_code)
             return False
-    except requests.exceptions.HTTPError as http_err:
-        logger.error(f'HTTP error occurred: {http_err}')
-    except requests.exceptions.Timeout as timeout_err:
-        logger.error(f'Timeout error: {timeout_err}')
     except Exception as e:
         logger.error('Server酱通知插件发送失败！')
-        logger.error(str(e))
-    return False
+        logger.error(e)
+        return False
 
-@notify(on="pushplus", name="pushplus通知插件")
-def pushplus_notification_wrapper(body, title, notify_type, *args, **kwargs):
-    token = kwargs['meta']['host']
-    url = 'http://www.pushplus.plus/send'
-    headers = {'Content-Type': 'application/json'}
-    payload = {
-        'token': token,
-        'title': title,
-        'content': body,
-        'template': 'html'
-    }
-    
-    try:
-        resp = requests.post(url, json=payload, headers=headers, timeout=10)
-        resp.raise_for_status()
-        json_response = resp.json()
-        if json_response.get('code') == 200:
-            logger.info('pushplus通知发送成功\n')
-            return True
-        else:
-            logger.error(f"pushplus通知发送失败, return code = {json_response.get('code')}")
-            return False
-    except requests.exceptions.HTTPError as http_err:
-        logger.error(f'HTTP error occurred: {http_err}')
-    except requests.exceptions.Timeout as timeout_err:
-        logger.error(f'Timeout error: {timeout_err}')
-    except requests.exceptions.RequestException as req_err:
-        logger.error(f'Request exception: {req_err}')
-    except Exception as e:
-        logger.error('pushplus通知插件发送失败！')
-        logger.error(str(e))
-    return False
+    # Returning True/False is a way to relay your status back to Apprise.
+    # Returning nothing (None by default) is always interpreted as a Success

--- a/Apprise/server_chan.py
+++ b/Apprise/server_chan.py
@@ -23,5 +23,34 @@ def server_chan_notification_wrapper(body, title, notify_type, *args, **kwargs):
         logger.error(e)
         return False
 
+@notify(on="pushplus", name="pushplus通知插件")
+def server_chan_notification_wrapper(body, title, notify_type, *args, **kwargs):
+    token = kwargs['meta']['host']
+    url = 'http://www.pushplus.plus/send'
+    headers = {'Content-Type': 'application/json'}
+    payload = {
+        'token': token,
+        'title': title,
+        'content': body,
+        'template': 'html'
+    }
+    
+    try:
+        resp = requests.post(url, json=payload, headers=headers)
+        if resp.status_code == 200:
+            if resp.json()['code'] == 200:
+                logger.info('pushplus通知发送成功\n')
+                return True
+            else:
+                logger.error('pushplus通知发送失败, return code = %d' % resp.json()['code'])
+                return False
+        else:
+            logger.error('pushplus通知发送失败, http return code = %s' % resp.status_code)
+            return False
+    except Exception as e:
+        logger.error('pushplus通知插件发送失败！')
+        logger.error(e)
+        return False
+
     # Returning True/False is a way to relay your status back to Apprise.
     # Returning nothing (None by default) is always interpreted as a Success

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@
 | ---                              | ---                                                                                                                              |
 | title                            | 通知标题                                                                                                                             |
 | body                             | 通知内容                                                                                                                             |
-| servers                          | Apprise格式服务器列表 - 详见[Apprise](https://github.com/caronc/apprise)<br>- 额外支持 [Server酱](https://sct.ftqq.com/) 格式为`ftqq://<SENDKEY>` |
+| servers                          | Apprise格式服务器列表 - 详见[Apprise](https://github.com/caronc/apprise)<br>- 额外支持 [Server酱](https://sct.ftqq.com/) 格式为`ftqq://<SENDKEY>` <br>- 额外支持 [pushplus](https://www.pushplus.plus/) 格式为`pushplus://<token>` |
 
 ## FAQ
 ##### 账号安全问题?

--- a/plugins/BuffAutoAcceptOffer.py
+++ b/plugins/BuffAutoAcceptOffer.py
@@ -220,8 +220,8 @@ class BuffAutoAcceptOffer:
                             for server in self.config["buff_auto_accept_offer"]["servers"]:
                                 apprise_obj.add(server)
                             apprise_obj.notify(
-                                self.config["buff_auto_accept_offer"]["buff_cookie_expired_notification"]["title"],
-                                self.config["buff_auto_accept_offer"]["buff_cookie_expired_notification"]["body"],
+                                title=self.config["buff_auto_accept_offer"]["buff_cookie_expired_notification"]["title"],
+                                body=self.config["buff_auto_accept_offer"]["buff_cookie_expired_notification"]["body"],
                             )
                         return
                 if self.development_mode and os.path.exists(MESSAGE_NOTIFICATION_DEV_FILE_PATH):

--- a/plugins/BuffAutoAcceptOffer.py
+++ b/plugins/BuffAutoAcceptOffer.py
@@ -8,6 +8,7 @@ import json5
 import requests
 from apprise.AppriseAsset import AppriseAsset
 from requests.exceptions import ProxyError
+from Apprise.server_chan import *
 
 from steampy.exceptions import ConfirmationExpected, InvalidCredentials
 from utils.buff_helper import get_valid_session_for_buff

--- a/plugins/BuffAutoAcceptOffer.py
+++ b/plugins/BuffAutoAcceptOffer.py
@@ -4,11 +4,11 @@ import pickle
 import time
 
 import apprise
+import Apprise
 import json5
 import requests
 from apprise.AppriseAsset import AppriseAsset
 from requests.exceptions import ProxyError
-from Apprise.server_chan import *
 
 from steampy.exceptions import ConfirmationExpected, InvalidCredentials
 from utils.buff_helper import get_valid_session_for_buff

--- a/plugins/BuffAutoOnSale.py
+++ b/plugins/BuffAutoOnSale.py
@@ -9,6 +9,7 @@ import apprise
 import json5
 import requests
 from apprise.AppriseAsset import AppriseAsset
+from Apprise.server_chan import *
 from bs4 import BeautifulSoup
 from requests.exceptions import ProxyError
 from steampy.exceptions import InvalidCredentials

--- a/plugins/BuffAutoOnSale.py
+++ b/plugins/BuffAutoOnSale.py
@@ -6,10 +6,10 @@ import time
 from typing import Any
 
 import apprise
+import Apprise
 import json5
 import requests
 from apprise.AppriseAsset import AppriseAsset
-from Apprise.server_chan import *
 from bs4 import BeautifulSoup
 from requests.exceptions import ProxyError
 from steampy.exceptions import InvalidCredentials

--- a/plugins/BuffProfitReport.py
+++ b/plugins/BuffProfitReport.py
@@ -8,6 +8,7 @@ import requests
 from _decimal import Decimal
 from apprise.AppriseAsset import AppriseAsset
 from apprise.AppriseAttachment import AppriseAttachment
+from Apprise.server_chan import *
 from requests.exceptions import ProxyError
 
 from steampy.exceptions import InvalidCredentials

--- a/plugins/BuffProfitReport.py
+++ b/plugins/BuffProfitReport.py
@@ -469,7 +469,9 @@ class BuffProfitReport:
                 for server in servers:
                     apprise_obj.add(server)
                 apprise_obj.notify(
-                    body='BUFF每日利润统计报告', attach=AppriseAttachment(report_file_path)
+                    title='BUFF每日利润统计报告',
+                    body='BUFF每日利润统计报告', 
+                    attach=AppriseAttachment(report_file_path)
                 )
             except ProxyError:
                 self.logger.error('[BuffProfitReport] 代理异常, 本软件可不需要代理或任何VPN')

--- a/plugins/BuffProfitReport.py
+++ b/plugins/BuffProfitReport.py
@@ -3,12 +3,12 @@ import pickle
 import time
 
 import apprise
+import Apprise
 import json5
 import requests
 from _decimal import Decimal
 from apprise.AppriseAsset import AppriseAsset
 from apprise.AppriseAttachment import AppriseAttachment
-from Apprise.server_chan import *
 from requests.exceptions import ProxyError
 
 from steampy.exceptions import InvalidCredentials

--- a/utils/buff_helper.py
+++ b/utils/buff_helper.py
@@ -10,6 +10,7 @@ import qrcode_terminal
 import requests
 from apprise.AppriseAsset import AppriseAsset
 from apprise.AppriseAttachment import AppriseAttachment
+from Apprise.server_chan import *
 from bs4 import BeautifulSoup
 
 from steampy.client import SteamClient
@@ -78,9 +79,14 @@ def login_to_buff_by_qrcode() -> str:
         apprise_obj = apprise.Apprise(asset=asset)
         for server in config["buff_auto_accept_offer"]["servers"]:
             apprise_obj.add(server)
+        # 检查是否应包括HTML内容
+        if config["buff_auto_accept_offer"]["buff_login_notification"]["include_qrcode_html_enable"]:
+            body_content = "保存图片到手机，用Buff扫码登陆" + html_content
+        else:
+            body_content = "请使用手机扫描上方二维码登录BUFF或打开程序目录下的qrcode.png扫描"
         apprise_obj.notify(
             title=config["buff_auto_accept_offer"]["buff_login_notification"]["title"],
-            body="保存图片到手机，用Buff扫码登陆"+html_content,
+            body=body_content,
             attach=AppriseAttachment("qrcode.png"),
         )
     logger.info("请使用手机扫描上方二维码登录BUFF或打开程序目录下的qrcode.png扫描")

--- a/utils/buff_helper.py
+++ b/utils/buff_helper.py
@@ -4,13 +4,13 @@ import time
 from typing import Dict
 
 import apprise
+import Apprise
 import json5
 import qrcode
 import qrcode_terminal
 import requests
 from apprise.AppriseAsset import AppriseAsset
 from apprise.AppriseAttachment import AppriseAttachment
-from Apprise.server_chan import *
 from bs4 import BeautifulSoup
 
 from steampy.client import SteamClient

--- a/utils/buff_helper.py
+++ b/utils/buff_helper.py
@@ -1,4 +1,5 @@
 import os
+import base64
 import time
 from typing import Dict
 
@@ -60,6 +61,13 @@ def login_to_buff_by_qrcode() -> str:
     img = qrcode.make(qr_code_url)
     img.save("qrcode.png")
     config = {}
+    
+    # 读取本地图片文件内容编码为Base64
+    with open("qrcode.png", "rb") as image_file:
+        encoded_string = base64.b64encode(image_file.read()).decode("utf-8")
+    
+    html_content = f"<br/><img src='data:image/png;base64,{encoded_string}' />"
+
     try:
         with open(CONFIG_FILE_PATH, "r", encoding=get_encoding(CONFIG_FILE_PATH)) as f:
             config = json5.load(f)
@@ -71,7 +79,8 @@ def login_to_buff_by_qrcode() -> str:
         for server in config["buff_auto_accept_offer"]["servers"]:
             apprise_obj.add(server)
         apprise_obj.notify(
-            config["buff_auto_accept_offer"]["buff_login_notification"]["title"],
+            title=config["buff_auto_accept_offer"]["buff_login_notification"]["title"],
+            body="保存图片到手机，用Buff扫码登陆"+html_content,
             attach=AppriseAttachment("qrcode.png"),
         )
     logger.info("请使用手机扫描上方二维码登录BUFF或打开程序目录下的qrcode.png扫描")

--- a/utils/static.py
+++ b/utils/static.py
@@ -110,7 +110,9 @@ DEFAULT_CONFIG_JSON = r"""
     // 二维码登录BUFF通知配置
     "buff_login_notification": {
       // 二维码登录BUFF通知标题（如不需要可直接删除）
-      "title": "请扫描二维码登录BUFF"
+      "title": "请扫描二维码登录BUFF",
+      // 是否开启传递 二维码图片
+      "include_qrcode_html_enable": false
     },
     // 通知服务器列表，使用Apprise格式，详见https://github.com/caronc/apprise/
     "servers": [


### PR DESCRIPTION
1、没有导入Apprise\server_chan.py 文件，导致编译版时漏编译，所以 ftqq通知失效
2、由于ftqq 只有5条免费消息，增加 pushplus 支持
3、增加设置开关，buff二维码登陆，可以直接html 形式 base64编码 发送通知，不用扫 ssh 上的二维码了。
![815c74a6cf9eb1266925bf2a319dbc03](https://github.com/Steamauto/Steamauto/assets/45261780/f3bc42c4-7235-4f77-8515-e0a1c5c6554b)
![2dc07b517d753f099a2a8bdc19d1bae3](https://github.com/Steamauto/Steamauto/assets/45261780/5253f51c-9329-4bbf-9ead-9be8cc10cf1a)
