### PR TITLE
修复打包缺少依赖PySocks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ PyCryptodome
 apscheduler
 protobuf
 pydantic >= 2.7.4
+PySocks


### PR DESCRIPTION
修复报错
from socks import ProxyError
Traceback (most recent call last):
  File "utils/logger.py", line 6, in <module>
ModuleNotFoundError: No module named 'socks'