### PR TITLE
修复直接运行程序后存储路径在用户文件夹的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ plugins/_*
 plugins/*External*
 maFiles
 accounts.txt
+.DS_Store

--- a/Steamauto.py
+++ b/Steamauto.py
@@ -21,6 +21,7 @@ from utils.logger import handle_caught_exception, logger
 from utils.notifier import send_notification
 from utils.old_version_patches import patch
 from utils.static import (
+    BASE_PATH,
     BUILD_INFO,
     CONFIG_FILE_PATH,
     CONFIG_FOLDER,
@@ -117,16 +118,16 @@ def init_files_and_params() -> int:
 
 @no_type_check
 def get_plugins_folder():
-    base_path = os.path.dirname(os.path.abspath(__file__))
+    # PLUGIN_FOLDER 现在已经是基于 BASE_PATH 的完整路径
     if hasattr(sys, "_MEIPASS"):
-        base_path = os.path.dirname(sys.executable)
-        if not os.path.exists(os.path.join(base_path, PLUGIN_FOLDER)):
-            shutil.copytree(os.path.join(sys._MEIPASS, PLUGIN_FOLDER), os.path.join(base_path, PLUGIN_FOLDER))
+        # 打包环境：从 _MEIPASS 复制插件到 BASE_PATH
+        if not os.path.exists(PLUGIN_FOLDER):
+            shutil.copytree(os.path.join(sys._MEIPASS, "plugins"), PLUGIN_FOLDER)
         else:
-            plugins = os.listdir(os.path.join(sys._MEIPASS, PLUGIN_FOLDER))
+            plugins = os.listdir(os.path.join(sys._MEIPASS, "plugins"))
             for plugin in plugins:
-                plugin_absolute = os.path.join(sys._MEIPASS, PLUGIN_FOLDER, plugin)
-                local_plugin_absolute = os.path.join(base_path, PLUGIN_FOLDER, plugin)
+                plugin_absolute = os.path.join(sys._MEIPASS, "plugins", plugin)
+                local_plugin_absolute = os.path.join(PLUGIN_FOLDER, plugin)
                 if os.path.isdir(plugin_absolute):
                     continue
                 if os.path.isdir(local_plugin_absolute):
@@ -142,7 +143,7 @@ def get_plugins_folder():
                             shutil.copy(plugin_absolute, local_plugin_absolute)
                         else:
                             logger.info("插件" + plugin + "与本地版本不同 由于已被加入白名单，不会自动更新")
-    return os.path.join(base_path, PLUGIN_FOLDER)
+    return PLUGIN_FOLDER
 
 
 def import_module_from_file(module_name, file_path):

--- a/utils/cloud_service.py
+++ b/utils/cloud_service.py
@@ -42,7 +42,11 @@ def get_platform_info():
 
 
 def get_user_uuid():
-    app_dir = os.path.expanduser("~/.steamauto")
+    # UUID 存储在程序所在目录下的 .steamauto 文件夹中
+    if hasattr(sys, "_MEIPASS"):
+        app_dir = os.path.join(os.path.dirname(sys.executable), ".steamauto")
+    else:
+        app_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".steamauto")
     uuid_file = os.path.join(app_dir, "uuid.txt")
     if not os.path.exists(app_dir):
         os.makedirs(app_dir)

--- a/utils/static.py
+++ b/utils/static.py
@@ -3,20 +3,29 @@ import sys
 
 from utils.build_info import info
 
+# 检测基础路径：打包后使用可执行文件所在目录，源码运行使用当前工作目录
+if hasattr(sys, "_MEIPASS"):
+    # PyInstaller 打包后的环境
+    BASE_PATH = os.path.dirname(sys.executable)
+else:
+    # 源码运行环境
+    BASE_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
 is_latest_version = False
 no_pause = False
 
 CURRENT_VERSION = "5.8.3"
 
-VERSION_FILE = "version.json"
-LOGS_FOLDER = "logs"
-CONFIG_FOLDER = "config"
-PLUGIN_FOLDER = "plugins"
+VERSION_FILE = os.path.join(BASE_PATH, "version.json")
+LOGS_FOLDER = os.path.join(BASE_PATH, "logs")
+CONFIG_FOLDER = os.path.join(BASE_PATH, "config")
+PLUGIN_FOLDER = os.path.join(BASE_PATH, "plugins")
 CONFIG_FILE_PATH = os.path.join(CONFIG_FOLDER, "config.json5")
 BUFF_COOKIES_FILE_PATH = os.path.join(CONFIG_FOLDER, "buff_cookies_{steam_username}.txt")
 UU_TOKEN_FILE_PATH = os.path.join(CONFIG_FOLDER, "uu_token_{steam_username}.txt")
 STEAM_ACCOUNT_INFO_FILE_PATH = os.path.join(CONFIG_FOLDER, "steam_account_info.json5")
-SESSION_FOLDER = "session"
+SESSION_FOLDER = os.path.join(BASE_PATH, "session")
+# 确保 session 文件夹存在
 os.makedirs(SESSION_FOLDER, exist_ok=True)
 SUPPORT_GAME_TYPES = [{"game": "csgo", "app_id": 730}, {"game": "dota2", "app_id": 570}]
 ECOSTEAM_RSAKEY_FILE = os.path.join(CONFIG_FOLDER, "rsakey.txt")


### PR DESCRIPTION
直接运行macos可执行文件后，由于运行目录默认在用户文件夹，导致用户信息未能正确存储在可执行文件的目录下